### PR TITLE
fix : legacyCreateStore is not found in redux. Reverted back the createStore

### DIFF
--- a/frontend/src/reducks/store/store.js
+++ b/frontend/src/reducks/store/store.js
@@ -1,7 +1,7 @@
 import {
   applyMiddleware,
   combineReducers,
-  legacycreateStore as configureStore,
+  createStore as configureStore,
 } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import { logger } from 'redux-logger';


### PR DESCRIPTION
legacyCreateStore is not found in redux. Reverted back the createStore